### PR TITLE
coding utf-8 is no longer needed

### DIFF
--- a/bf_interpreter.rb
+++ b/bf_interpreter.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 class Brainfuck
   def initialize(src)
     @saddr = 0


### PR DESCRIPTION
Ruby 2.0からはUTF-8がデフォルトなのでいらないです